### PR TITLE
Double spend prevention

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/stroomnetwork/btcwallet/run"
+
+func main() {
+	run.RunExample()
+}

--- a/run/btcwallet.go
+++ b/run/btcwallet.go
@@ -24,22 +24,6 @@ var (
 	cfg *config
 )
 
-// StartWallet is a work-around main function that is required since deferred
-// functions (such as log flushing) are not called with calls to os.Exit.
-// Instead, main runs this function and checks for a non-nil error, at which
-// point any defers have already run, and if the error is non-nil, the program
-// can be exited with an error exit status.
-func StartWallet(signer frost.ISigner) error {
-	_, err := RunWallet(signer)
-	if err != nil {
-		return err
-	}
-
-	<-interruptHandlersDone
-	log.Info("Shutdown complete")
-	return nil
-}
-
 func RunWallet(signer frost.ISigner) (*wallet.Wallet, error) {
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.

--- a/run/signer_with_wallet_example.go
+++ b/run/signer_with_wallet_example.go
@@ -51,7 +51,7 @@ func RunExample() {
 		return
 	}
 
-	simpleTx, err := w.CreateTxWithRedemptionIdAndCheckDoubleSpend(nil, nil, 3, &waddrmgr.KeyScopeBIP0086, accounts.Accounts[1].AccountNumber, []*wire.TxOut{txOut}, 1, 1000, wallet.CoinSelectionLargest, false)
+	simpleTx, err := w.CheckDoubleSpendAndCreateTxWithRedemptionId(nil, nil, 3, &waddrmgr.KeyScopeBIP0086, accounts.Accounts[1].AccountNumber, []*wire.TxOut{txOut}, 1, 1000, wallet.CoinSelectionLargest, false)
 	if err != nil {
 		log.Info(err)
 		return
@@ -62,7 +62,7 @@ func RunExample() {
 		return
 	}
 
-	/*spent, _, err := w.IsRedemptionAlreadySpent(2, wallet.NewBlockIdentifierFromHeight(1), wallet.NewBlockIdentifierFromHeight(8000))
+	/*spent, _, err := w.IsRedemptionIdAlreadySpent(2, wallet.NewBlockIdentifierFromHeight(1), wallet.NewBlockIdentifierFromHeight(8000))
 	if err != nil {
 		log.Info(err)
 		return

--- a/run/signer_with_wallet_example.go
+++ b/run/signer_with_wallet_example.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func main() {
+func RunExample() {
 	// Use all processor cores.
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -43,7 +43,7 @@ func main() {
 		log.Info(err)
 		return
 	}
-	txOut := wire.NewTxOut(100000000, p2shAddr)
+	txOut := wire.NewTxOut(10000000, p2shAddr)
 
 	accounts, err := w.Accounts(waddrmgr.KeyScopeBIP0086)
 	if err != nil {
@@ -51,7 +51,7 @@ func main() {
 		return
 	}
 
-	simpleTx, err := w.CreateSimpleTx(&waddrmgr.KeyScopeBIP0086, accounts.Accounts[1].AccountNumber, []*wire.TxOut{txOut}, 1, 1, wallet.CoinSelectionLargest, false)
+	simpleTx, err := w.CreateTxWithRedemptionIdAndCheckDoubleSpend(nil, nil, 3, &waddrmgr.KeyScopeBIP0086, accounts.Accounts[1].AccountNumber, []*wire.TxOut{txOut}, 1, 1000, wallet.CoinSelectionLargest, false)
 	if err != nil {
 		log.Info(err)
 		return
@@ -62,6 +62,13 @@ func main() {
 		return
 	}
 
+	/*spent, _, err := w.IsRedemptionAlreadySpent(2, wallet.NewBlockIdentifierFromHeight(1), wallet.NewBlockIdentifierFromHeight(8000))
+	if err != nil {
+		log.Info(err)
+		return
+	}
+	log.Info("Spend: ", spent)
+	*/
 	<-interruptHandlersDone
 	log.Info("Shutdown complete")
 }

--- a/run/signer_with_wallet_example.go
+++ b/run/signer_with_wallet_example.go
@@ -62,13 +62,6 @@ func RunExample() {
 		return
 	}
 
-	/*spent, _, err := w.IsRedemptionIdAlreadySpent(2, wallet.NewBlockIdentifierFromHeight(1), wallet.NewBlockIdentifierFromHeight(8000))
-	if err != nil {
-		log.Info(err)
-		return
-	}
-	log.Info("Spend: ", spent)
-	*/
 	<-interruptHandlersDone
 	log.Info("Shutdown complete")
 }

--- a/stroom/redemption.go
+++ b/stroom/redemption.go
@@ -1,0 +1,59 @@
+package stroom
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stroomnetwork/btcwallet/waddrmgr"
+	"github.com/stroomnetwork/btcwallet/wallet"
+	"github.com/stroomnetwork/btcwallet/wallet/txauthor"
+	"golang.org/x/net/context"
+	"time"
+)
+
+func IsAlreadySpent(w *wallet.Wallet, redemptionId uint32, start *wallet.BlockIdentifier, end *wallet.BlockIdentifier) (bool, chainhash.Hash, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gtr, err := w.GetTransactions(start, end, "", ctx.Done())
+	if err != nil {
+		return false, nilHash(), err
+	}
+
+	for _, block := range gtr.MinedTransactions {
+		isPresent, hash, err := isRedemptionIdPresent(w, redemptionId, block.Transactions)
+		if isPresent {
+			return isPresent, hash, err
+		}
+	}
+
+	// TODO(dp) to include unmined transactions block height has to be -1
+	return isRedemptionIdPresent(w, redemptionId, gtr.UnminedTransactions)
+}
+
+func isRedemptionIdPresent(w *wallet.Wallet, redemptionId uint32, txs []wallet.TransactionSummary) (bool, chainhash.Hash, error) {
+	for _, tx := range txs {
+		if tx.MyInputs != nil {
+			txDetails, _ := wallet.UnstableAPI(w).TxDetails(tx.Hash)
+			for _, input := range txDetails.MsgTx.TxIn {
+				if input.Sequence == redemptionId {
+					return true, txDetails.Hash, nil
+				}
+			}
+		}
+	}
+	return false, nilHash(), nil
+}
+
+func nilHash() chainhash.Hash {
+	return chainhash.Hash{}
+}
+
+func CreateSimpleTxWithRedemptionId(w *wallet.Wallet, coinSelectKeyScope *waddrmgr.KeyScope,
+	account uint32, outputs []*wire.TxOut, minconf int32,
+	satPerKb btcutil.Amount, coinSelectionStrategy wallet.CoinSelectionStrategy,
+	dryRun bool, redemptionId uint32, optFuncs ...wallet.TxCreateOption) (*txauthor.AuthoredTx, error) {
+
+	spent, hash, err := IsAlreadySpent(w, redemptionId, nil, nil)
+}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -141,6 +141,16 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 	account uint32, minconf int32, feeSatPerKb btcutil.Amount,
 	strategy CoinSelectionStrategy, dryRun bool,
 	selectedUtxos []wire.OutPoint,
+	allowUtxo func(utxo wtxmgr.Credit) bool) (
+	*txauthor.AuthoredTx, error) {
+	return w.txToOutputsWithRedemptionId(outputs, coinSelectKeyScope, changeKeyScope, account, minconf, feeSatPerKb, strategy, dryRun, selectedUtxos, allowUtxo, 0)
+}
+
+func (w *Wallet) txToOutputsWithRedemptionId(outputs []*wire.TxOut,
+	coinSelectKeyScope, changeKeyScope *waddrmgr.KeyScope,
+	account uint32, minconf int32, feeSatPerKb btcutil.Amount,
+	strategy CoinSelectionStrategy, dryRun bool,
+	selectedUtxos []wire.OutPoint,
 	allowUtxo func(utxo wtxmgr.Credit) bool, redemptionID uint32) (
 	*txauthor.AuthoredTx, error) {
 

--- a/wallet/redemption_test.go
+++ b/wallet/redemption_test.go
@@ -1,0 +1,84 @@
+package wallet
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stroomnetwork/btcwallet/waddrmgr"
+	"github.com/stroomnetwork/btcwallet/wallet/txauthor"
+	"testing"
+)
+
+// TODO(dp) test mined double spend with miner.Client.Generate(1)
+
+func TestUnminedDoubleSpendFromSameWallet(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	_ = addUtxoToWallet(t, w)
+
+	tx, err := createTX(w)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tx)
+
+	w.PublishTransaction(tx.Tx, "")
+
+	// double spend the same redemptionId
+	tx, err = createTX(w)
+
+	assert.Error(t, err)
+	assert.Nil(t, tx)
+}
+
+func createTX(w *Wallet) (*txauthor.AuthoredTx, error) {
+
+	var redemptionId uint32 = 1
+
+	return w.CreateTxWithRedemptionIdAndCheckDoubleSpend(NewBlockIdentifierFromHeight(0), NewBlockIdentifierFromHeight(0),
+		redemptionId, &waddrmgr.KeyScopeBIP0049Plus, 0, []*wire.TxOut{getTxOut()}, 1, 100,
+		CoinSelectionLargest, false)
+}
+
+func addUtxoToWallet(t *testing.T, w *Wallet) error {
+	keyScope := waddrmgr.KeyScopeBIP0049Plus
+	addr, err := w.CurrentAddress(0, keyScope)
+	if err != nil {
+		t.Fatalf("unable to get current address: %v", addr)
+	}
+	p2shAddr, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("unable to convert wallet address to p2sh: %v", err)
+	}
+
+	incomingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{},
+		},
+		TxOut: []*wire.TxOut{},
+	}
+	for amt := int64(5000); amt <= 125000; amt += 10000 {
+		incomingTx.AddTxOut(wire.NewTxOut(amt, p2shAddr))
+	}
+
+	addUtxo(t, w, incomingTx)
+	return err
+}
+
+func getTxOut() *wire.TxOut {
+	addr, err := btcutil.DecodeAddress("SR9zEMt5qG7o1Q7nGcLPCMqv5BrNHcw2zi", &chaincfg.SimNetParams)
+	if err != nil {
+		log.Info(err)
+		return nil
+	}
+	p2shAddr, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		log.Info(err)
+		return nil
+	}
+	return wire.NewTxOut(10000, p2shAddr)
+}

--- a/wallet/redemption_test.go
+++ b/wallet/redemption_test.go
@@ -48,7 +48,8 @@ func createTX(t *testing.T, w *Wallet) (*txauthor.AuthoredTx, error) {
 
 	var redemptionId uint32 = 1
 
-	return w.CreateTxWithRedemptionIdAndCheckDoubleSpend(NewBlockIdentifierFromHeight(0), NewBlockIdentifierFromHeight(testBlockHeight),
+	return w.CheckDoubleSpendAndCreateTxWithRedemptionId(
+		NewBlockIdentifierFromHeight(0), NewBlockIdentifierFromHeight(testBlockHeight),
 		redemptionId, &waddrmgr.KeyScopeBIP0049Plus, 0, []*wire.TxOut{getTxOut(t)}, 1, 100,
 		CoinSelectionLargest, false)
 }

--- a/wallet/redemption_test.go
+++ b/wallet/redemption_test.go
@@ -11,49 +11,55 @@ import (
 	"testing"
 )
 
-// TODO(dp) test mined double spend with miner.Client.Generate(1)
+func TestMinedTxDoubleSpend(t *testing.T) {
+	doubleSpendTest(t, true)
+}
 
-func TestUnminedDoubleSpendFromSameWallet(t *testing.T) {
+func TestUnminedTxDoubleSpendFrom(t *testing.T) {
+	doubleSpendTest(t, false)
+}
+
+func doubleSpendTest(t *testing.T, mineTx bool) {
 	t.Parallel()
 
 	w, cleanup := testWallet(t)
 	defer cleanup()
 
-	_ = addUtxoToWallet(t, w)
+	addUtxoToWallet(t, w)
 
-	tx, err := createTX(w)
-
+	tx, err := createTX(t, w)
 	assert.NoError(t, err)
 	assert.NotNil(t, tx)
 
-	w.PublishTransaction(tx.Tx, "")
+	if mineTx {
+		addUtxo(t, w, tx.Tx)
+	} else {
+		_ = w.PublishTransaction(tx.Tx, "")
+	}
 
 	// double spend the same redemptionId
-	tx, err = createTX(w)
+	tx, err = createTX(t, w)
 
 	assert.Error(t, err)
 	assert.Nil(t, tx)
 }
 
-func createTX(w *Wallet) (*txauthor.AuthoredTx, error) {
+func createTX(t *testing.T, w *Wallet) (*txauthor.AuthoredTx, error) {
 
 	var redemptionId uint32 = 1
 
-	return w.CreateTxWithRedemptionIdAndCheckDoubleSpend(NewBlockIdentifierFromHeight(0), NewBlockIdentifierFromHeight(0),
-		redemptionId, &waddrmgr.KeyScopeBIP0049Plus, 0, []*wire.TxOut{getTxOut()}, 1, 100,
+	return w.CreateTxWithRedemptionIdAndCheckDoubleSpend(NewBlockIdentifierFromHeight(0), NewBlockIdentifierFromHeight(testBlockHeight),
+		redemptionId, &waddrmgr.KeyScopeBIP0049Plus, 0, []*wire.TxOut{getTxOut(t)}, 1, 100,
 		CoinSelectionLargest, false)
 }
 
-func addUtxoToWallet(t *testing.T, w *Wallet) error {
+func addUtxoToWallet(t *testing.T, w *Wallet) {
 	keyScope := waddrmgr.KeyScopeBIP0049Plus
 	addr, err := w.CurrentAddress(0, keyScope)
-	if err != nil {
-		t.Fatalf("unable to get current address: %v", addr)
-	}
+	assert.NoError(t, err)
+
 	p2shAddr, err := txscript.PayToAddrScript(addr)
-	if err != nil {
-		t.Fatalf("unable to convert wallet address to p2sh: %v", err)
-	}
+	assert.NoError(t, err)
 
 	incomingTx := &wire.MsgTx{
 		TxIn: []*wire.TxIn{
@@ -66,19 +72,14 @@ func addUtxoToWallet(t *testing.T, w *Wallet) error {
 	}
 
 	addUtxo(t, w, incomingTx)
-	return err
 }
 
-func getTxOut() *wire.TxOut {
+func getTxOut(t *testing.T) *wire.TxOut {
 	addr, err := btcutil.DecodeAddress("SR9zEMt5qG7o1Q7nGcLPCMqv5BrNHcw2zi", &chaincfg.SimNetParams)
-	if err != nil {
-		log.Info(err)
-		return nil
-	}
+	assert.NoError(t, err)
+
 	p2shAddr, err := txscript.PayToAddrScript(addr)
-	if err != nil {
-		log.Info(err)
-		return nil
-	}
+	assert.NoError(t, err)
+
 	return wire.NewTxOut(10000, p2shAddr)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1204,6 +1204,7 @@ type (
 		resp                  chan createTxResponse
 		selectUtxos           []wire.OutPoint
 		allowUtxo             func(wtxmgr.Credit) bool
+		redemptionID          uint32
 	}
 	createTxResponse struct {
 		tx  *txauthor.AuthoredTx
@@ -1246,6 +1247,7 @@ out:
 				txr.changeKeyScope, txr.account, txr.minconf,
 				txr.feeSatPerKB, txr.coinSelectionStrategy,
 				txr.dryRun, txr.selectUtxos, txr.allowUtxo,
+				txr.redemptionID,
 			)
 
 			release()
@@ -1325,6 +1327,16 @@ func (w *Wallet) CreateSimpleTx(coinSelectKeyScope *waddrmgr.KeyScope,
 	satPerKb btcutil.Amount, coinSelectionStrategy CoinSelectionStrategy,
 	dryRun bool, optFuncs ...TxCreateOption) (*txauthor.AuthoredTx, error) {
 
+	return w.CreateSimpleTxWithRedemptionId(
+		coinSelectKeyScope, account, outputs, minconf, satPerKb,
+		coinSelectionStrategy, dryRun, 0, optFuncs...)
+}
+
+func (w *Wallet) CreateSimpleTxWithRedemptionId(coinSelectKeyScope *waddrmgr.KeyScope,
+	account uint32, outputs []*wire.TxOut, minconf int32,
+	satPerKb btcutil.Amount, coinSelectionStrategy CoinSelectionStrategy,
+	dryRun bool, redemptionId uint32, optFuncs ...TxCreateOption) (*txauthor.AuthoredTx, error) {
+
 	opts := defaultTxCreateOptions()
 	for _, optFunc := range optFuncs {
 		optFunc(opts)
@@ -1348,6 +1360,7 @@ func (w *Wallet) CreateSimpleTx(coinSelectKeyScope *waddrmgr.KeyScope,
 		resp:                  make(chan createTxResponse),
 		selectUtxos:           opts.selectUtxos,
 		allowUtxo:             opts.allowUtxo,
+		redemptionID:          redemptionId,
 	}
 	w.createTxRequests <- req
 	resp := <-req.resp

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1242,7 +1242,7 @@ out:
 				release = heldUnlock.release
 			}
 
-			tx, err := w.txToOutputs(
+			tx, err := w.txToOutputsWithRedemptionId(
 				txr.outputs, txr.coinSelectKeyScope,
 				txr.changeKeyScope, txr.account, txr.minconf,
 				txr.feeSatPerKB, txr.coinSelectionStrategy,


### PR DESCRIPTION
Before creating a tx check whether the specified redemptionId was already spent.