### PR TITLE
Fix NPE for bicoind

### DIFF
--- a/chain/bitcoind.go
+++ b/chain/bitcoind.go
@@ -14,7 +14,11 @@ func SetupBitcoind(cfg *BitcoindConfig) (*BitcoindClient, error) {
 		if err != nil {
 			log.Errorf("error creating bitcoind connection: %v", err)
 		}
-		c <- chainConn
+		if chainConn == nil {
+			log.Errorf("chainConn is nil")
+		} else {
+			c <- chainConn
+		}
 	}()
 
 	select {


### PR DESCRIPTION
Fix for:

```

2024-11-06T21:57:26.765Zpanic: runtime error: invalid memory address or nil pointer dereference | panic: runtime error: invalid memory address or nil pointer dereference
-- | --
  | 2024-11-06T21:57:26.765Z[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x9b505c] | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x9b505c]
  | 2024-11-06T21:57:26.765Zgoroutine 96 [running]: | goroutine 96 [running]:
  | 2024-11-06T21:57:26.765Zgithub.com/stroomnetwork/btcwallet/chain.(*BitcoindConn).NewBitcoindClient(...) | github.com/stroomnetwork/btcwallet/chain.(*BitcoindConn).NewBitcoindClient(...)
  | 2024-11-06T21:57:26.765Z	/home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/chain/bitcoind_conn.go:369 | /home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/chain/bitcoind_conn.go:369
  | 2024-11-06T21:57:26.765Zgithub.com/stroomnetwork/btcwallet/chain.SetupBitcoind(0xc00057ec60) | github.com/stroomnetwork/btcwallet/chain.SetupBitcoind(0xc00057ec60)
  | 2024-11-06T21:57:26.765Z	/home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/chain/bitcoind.go:22 +0x13c | /home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/chain/bitcoind.go:22 +0x13c
  | 2024-11-06T21:57:26.765Zgithub.com/stroomnetwork/btcwallet/run.rpcClientConnectLoop(0x0, 0xc00020f440, 0xc00057ec60) | github.com/stroomnetwork/btcwallet/run.rpcClientConnectLoop(0x0, 0xc00020f440, 0xc00057ec60)
  | 2024-11-06T21:57:26.765Z	/home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/run/btcwallet.go:327 +0x105 | /home/runner/go/pkg/mod/github.com/stroomnetwork/btcwallet@v0.0.13-0.20241106150458-1c87d83d363d/run/btcwallet.go:327 +0x105
  | 2024-11-06T21:57:26.765Zcreated by github.com/stroomnetwork/btcwallet/run.doInit in goroutine 26


```